### PR TITLE
Update GoReleaser configuration to use Bun builder

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,30 +1,13 @@
-version: 2
-
-before:
-  hooks:
-    - make build
-
 builds:
   - id: hops
+    builder: bun
     binary: hops
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    skip: true
-
-archives:
-  - id: hops
-    ids:
-      - hops
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-    formats:
-      - tar.gz
-    files:
-      - hops
-
-checksum:
-  name_template: "checksums.txt"
+    targets:
+      - darwin-arm64
+    flags:
+      - --compile
+      - --outfile hops
+    skip: false
 
 changelog:
   sort: asc
@@ -38,3 +21,6 @@ release:
     owner: revett
     name: hops
   draft: true
+
+checksum:
+  name_template: "checksums.txt"


### PR DESCRIPTION
- Replace Go build configuration with Bun builder setup
- Configure Bun to compile with --compile flag and custom outfile
- Remove archives section as Bun handles binary generation directly
- Move checksum configuration to end of file for better organization