### PR TITLE
Brewfile → Trust hops.yml taps by default

### DIFF
--- a/src/services/brewfile.ts
+++ b/src/services/brewfile.ts
@@ -50,12 +50,13 @@ const displayItems = (
   items: Set<string>,
   title: string,
   prefix: string,
+  suffix = "",
 ) => {
   lines.push(`\n# ${title}\n`);
 
   if (items.size > 0) {
     for (const i of [...items].sort()) {
-      lines.push(`${prefix} "${i}"`);
+      lines.push(`${prefix} "${i}"${suffix}`);
     }
   } else {
     lines.push("# None.");
@@ -126,7 +127,11 @@ export async function generateBrewfile(
   lines.push(`# Machine: ${machine}`);
   lines.push(`# Last updated: ${dayjs().format("YYYY-MM-DD HH:mm:ss")}`);
 
-  displayItems(lines, taps, "Taps", "tap");
+  // Homebrew 6.0 trusts third-party taps by default
+  // (HOMEBREW_REQUIRE_TAP_TRUST), so `brew bundle install` refuses to load from
+  // any untrusted tap. A tap in hops.yml is one the user chose to install from,
+  // so mark them all trusted to keep `hops apply` working.
+  displayItems(lines, taps, "Taps", "tap", ", trusted: true");
   displayItems(lines, formulae, "Formulae", "brew");
   displayItems(lines, casks, "Casks", "cask");
   displayItems(lines, cursor, "Cursor", "vscode");


### PR DESCRIPTION
Closes #97 

## Problem

- Homebrew 6.0 trusts third-party taps by default via `HOMEBREW_REQUIRE_TAP_TRUST`, so `brew bundle install` now refuses to load anything from an untrusted tap
- Because hops emitted bare `tap "<name>"` lines, every third-party tap in a user's `hops.yml` broke `hops apply` on Homebrew >= 6.0

## Changes

- Emit each tap as `tap "<name>", trusted: true` in the generated Brewfile

## Why

- A tap in `hops.yml` is, by definition, one the user has chosen to install from, so hops can safely mark them all trusted
- The Brewfile `trusted:` option grants trust in the same process that loads the tap, unlike a standalone `brew trust` call, so it works reliably