### PR TITLE
Fix cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@
 - `shared` is a reserved machine name, merged with the target machine during generation
 - Run logging writes a colour-stripped transcript of each run to `~/.hops.log` (on by default,
   `logging: false` in `hops.yml` disables it); a logging failure must never abort a command
+- `apply` cleanup runs three brew commands in order: `brew bundle --force cleanup` (uninstall
+  non-Brewfile packages), `brew autoremove` (orphaned deps), `brew cleanup` (stale caches/old
+  versions). The latter two are required because `brew bundle cleanup` previews `brew cleanup`'s work
+  but never executes it, so omitting them left the same removal list resurfacing on every run
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,21 @@ Yes, as part of the [v4.5.0](https://brew.sh/2025/04/29/homebrew-4.5.0/) release
 April 2025, the `brew bundle` command looks for VS Code variants, see
 [#19545](https://github.com/Homebrew/brew/pull/19545).
 
+**What does the cleanup step actually remove?**
+
+When you confirm "Uninstall these packages?" during `apply`, hops runs three Homebrew commands in
+sequence:
+
+1. `brew bundle --force cleanup` → uninstalls formulae and casks that are installed but absent from
+   the generated Brewfile
+1. `brew autoremove` → removes orphaned dependencies (e.g. an old `python@x.y` left behind when a
+   formula bumped its Python version)
+1. `brew cleanup` → purges stale download caches and old formula/cask versions
+
+The last two were added in v0.8.1. Before that, only step 1 ran, so the orphaned dependencies and
+stale caches it could not touch reappeared in the list on every single run. `brew cleanup` runs
+without `--scrub`, so recent caches are kept and not re-downloaded on the next install.
+
 ## Project
 
 ### Releases

--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ April 2025, the `brew bundle` command looks for VS Code variants, see
 When you confirm "Uninstall these packages?" during `apply`, hops runs three Homebrew commands in
 sequence:
 
-1. `brew bundle --force cleanup` → uninstalls formulae and casks that are installed but absent from
+1. `brew bundle --force cleanup` → Uninstalls formulae and casks that are installed but absent from
    the generated Brewfile
-1. `brew autoremove` → removes orphaned dependencies (e.g. an old `python@x.y` left behind when a
+1. `brew autoremove` → Removes orphaned dependencies (e.g. an old `python@x.y` left behind when a
    formula bumped its Python version)
-1. `brew cleanup` → purges stale download caches and old formula/cask versions
+1. `brew cleanup` → Purges stale download caches and old formula/cask versions
 
 The last two were added in v0.8.1. Before that, only step 1 ran, so the orphaned dependencies and
 stale caches it could not touch reappeared in the list on every single run. `brew cleanup` runs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hops",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/cli.ts",
   "repository": "git@github.com:revett/hops.git",
   "author": "revett <2796074+revett@users.noreply.github.com>",

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -137,7 +137,20 @@ const action: (options: ApplyOptions) => Promise<Result<void, Error>> = async (
 
     log.step(pc.bold("Removing packages"));
     console.log(pc.gray("│"));
-    const cleanup = await homebrew.forceCleanup(config.brewfile);
+    const bundleCleanup = await homebrew.forceCleanup(config.brewfile);
+    if (bundleCleanup.isErr()) {
+      return err(bundleCleanup.error);
+    }
+
+    // `brew bundle --force cleanup` only uninstalls formulae/casks absent from
+    // the Brewfile; it leaves orphaned dependencies and stale caches behind,
+    // which is why the same list resurfaced on every apply. Clear them too.
+    const autoremove = await homebrew.autoremove();
+    if (autoremove.isErr()) {
+      return err(autoremove.error);
+    }
+
+    const cleanup = await homebrew.cleanup();
     if (cleanup.isErr()) {
       return err(cleanup.error);
     }

--- a/src/services/homebrew.ts
+++ b/src/services/homebrew.ts
@@ -160,6 +160,52 @@ export async function forceCleanup(
   return ok(undefined);
 }
 
+// Removes unused dependencies left behind when a formula stops depending on
+// them (e.g. awscli bumping its Python version orphans the old python@x.y).
+// `brew bundle --force cleanup` does not do this, so we run it explicitly.
+export async function autoremove(): Promise<Result<void, Error>> {
+  const result = await execa({
+    reject: false,
+    stdin: "inherit",
+    stdout: ["inherit", "pipe"],
+  })`brew autoremove`;
+
+  capture(result.stdout);
+
+  if (result.exitCode !== 0) {
+    return err(
+      new Error(
+        `Homebrew command failed with exit code ${result.exitCode}: brew autoremove`,
+      ),
+    );
+  }
+
+  return ok(undefined);
+}
+
+// Purges stale download caches and old formula/cask versions. `brew cleanup`
+// acts by default (unlike `brew bundle cleanup`, which needs --force), so no
+// flag is needed. We deliberately omit --scrub so recent caches survive.
+export async function cleanup(): Promise<Result<void, Error>> {
+  const result = await execa({
+    reject: false,
+    stdin: "inherit",
+    stdout: ["inherit", "pipe"],
+  })`brew cleanup`;
+
+  capture(result.stdout);
+
+  if (result.exitCode !== 0) {
+    return err(
+      new Error(
+        `Homebrew command failed with exit code ${result.exitCode}: brew cleanup`,
+      ),
+    );
+  }
+
+  return ok(undefined);
+}
+
 export async function install(
   brewfilePath: string,
 ): Promise<Result<void, Error>> {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make `apply` cleanup actually clear Homebrew leftovers by running `brew autoremove` and `brew cleanup` after `brew bundle --force cleanup`. This removes orphaned deps and stale caches so they don’t reappear on every run.

- **Bug Fixes**
  - Add per-step error handling for the three-step cleanup.
  - Update docs with a cleanup FAQ (we omit `--scrub` to keep recent caches); bump `hops` to `0.8.1`.

<sup>Written for commit 2810aa7395f4e2c021fc1f476f7b5cba6ae14131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/revett/hops/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

